### PR TITLE
Remove the patch number from dune lang version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.7.0)
+(lang dune 2.7)
 (name lilac)


### PR DESCRIPTION
This part of the version number is ignored by dune and results in a
warning 'The ".0" part is ignored here'
